### PR TITLE
Add Panic and Fatal log levels to the logging interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # YAGL (Yet Another Go Logger)
 
+[![Coverage Status](https://coveralls.io/repos/github/C0rWin/yagl/badge.svg?branch=coveralls)](https://coveralls.io/github/C0rWin/yagl?branch=coveralls)
+[![Build Status](https://github.com/C0rwin/yagl/actions/workflows/go.yml/badge.svg)](https://github.com/C0rwin/yagl/actions/workflows/go.yml/badge.svg)
+
+
 YAGL is a lightweight, powerful, and flexible logging library for Go. It provides an alternative implementation for application logging, focusing on simplicity and customizability.
 
 ## Features

--- a/interface.go
+++ b/interface.go
@@ -15,6 +15,10 @@ const (
 	Warn
 	// Error log level
 	Error
+	// Panic log level
+	Panic
+	// Fatal log level
+	Fatal
 )
 
 var logLevelStrings = map[LogLevel]string{
@@ -22,6 +26,8 @@ var logLevelStrings = map[LogLevel]string{
 	Warn:  "WARN",
 	Info:  "INFO",
 	Error: "ERROR",
+	Panic: "PANIC",
+	Fatal: "FATAL",
 }
 
 // String returns the string representation of the LogLevel.

--- a/logger.go
+++ b/logger.go
@@ -132,6 +132,11 @@ func (l *Logger) Logf(level LogLevel, msg string, args ...interface{}) {
 	}
 
 	bOut := bytes.Join([][]byte{buffer.Bytes(), []byte("\n")}, []byte(""))
+	// Check if the log level is panic, output the message and panic
+	if level == Panic {
+		panic(string(bOut))
+	}
+
 	// Write to the appropriate writer
 	if out, exists := l.levelOuts[level]; exists {
 		if out == nil {
@@ -160,6 +165,10 @@ func (l *Logger) Logf(level LogLevel, msg string, args ...interface{}) {
 		}
 	}
 
+	// Check if the log level is fatal, output the message and exit
+	if level == Fatal {
+		os.Exit(1)
+	}
 }
 
 // Setup sets the logger options

--- a/settings.go
+++ b/settings.go
@@ -57,6 +57,8 @@ func DefaultStd(l *Logger) {
 		Info:  os.Stdout,
 		Warn:  os.Stdout,
 		Error: os.Stderr,
+		Panic: os.Stderr,
+		Fatal: os.Stderr,
 	}
 }
 


### PR DESCRIPTION
**Add Panic and Fatal log levels to the logging interface**

- Introduced `Panic` and `Fatal` log levels in the logging interface (`interface.go`):
  - Added `Panic` and `Fatal` constants to the `LogLevel` enumeration.
  - Updated the `logLevelStrings` map to include string representations for `Panic` and `Fatal`.

- Enhanced logging functionality within the logger (`logger.go`):
  - Implemented behavior for the `Panic` log level, which causes a panic with the log message.
  - Implemented behavior for the `Fatal` log level, which outputs the message and exits the application with a status code of 1.

- Updated default logger settings in `settings.go`:
  - Set output destinations for `Panic` and `Fatal` log levels to standard error (os.Stderr).
